### PR TITLE
Fix VPN link variable in bot

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -200,7 +200,7 @@ async def generate_vpn(message: Message, email: str = ""):
         await message.answer(
             f"✅ Доступ предоставлен на <b>7 дней</b>.\n\n"
             f"📲 Скопируй эту ссылку и вставь в приложение <b>Amnezia</b>:\n"
-            f"<code>{link}</code>",
+            f"<code>{config_url}</code>",
             reply_markup=main_menu()
         )
 


### PR DESCRIPTION
## Summary
- Use config_url variable when sending VPN link

## Testing
- `python -m py_compile bot.py`


------
https://chatgpt.com/codex/tasks/task_e_68a5e87b3efc832d9be26d00c23e3723