### PR TITLE
chore: remove unused os import

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1,4 +1,3 @@
-import os
 import time
 import sqlite3
 import json


### PR DESCRIPTION
## Summary
- remove unused `os` import in bot

## Testing
- `ruff check --select F401 bot.py`
- `ruff check bot.py` *(fails: F821 undefined name `subprocess`)*

------
https://chatgpt.com/codex/tasks/task_e_68a5fc67ebd8832d85644b0024b1e2b4